### PR TITLE
feat: support for recursive structures

### DIFF
--- a/test/runtime/value/cast/recursive.ts
+++ b/test/runtime/value/cast/recursive.ts
@@ -95,4 +95,227 @@ describe('value/cast/Recursive', () => {
     //   ],
     // })
   })
+
+  it('should handle simple circular structures', () => {
+    const input = {
+      a: 'hello',
+    }
+
+    // @ts-expect-error
+    input.b = input
+
+    const schema = Type.Recursive((This) =>
+      Type.Object({
+        a: Type.String(),
+        b: This,
+      }),
+    )
+
+    const result = Value.Cast(schema, input)
+
+    Assert.IsEqual(result, input)
+  })
+
+  it('should handle type coercion in circular structures #1', () => {
+    const input = {
+      id: 1,
+      nodes: [],
+    }
+
+    // @ts-expect-error
+    input.nodes = [input]
+
+    const schema = Type.Recursive((This) =>
+      Type.Object({
+        id: Type.String(),
+        nodes: Type.Array(This),
+      }),
+    )
+
+    const result = Value.Cast(schema, input)
+
+    const output = {
+      id: '',
+      nodes: [],
+    }
+
+    // @ts-expect-error
+    output.nodes = [output]
+
+    Assert.IsEqual(result, output)
+  })
+
+  it('should handle type coercion in circular structures #2', () => {
+    const input = {
+      value: 42, // number should be cast to string
+      next: null,
+    }
+
+    // @ts-expect-error
+    input.next = input
+
+    const schema = Type.Recursive((This) =>
+      Type.Object({
+        value: Type.String(),
+        next: Type.Union([This, Type.Null()]),
+      }),
+    )
+
+    const result = Value.Cast(schema, input)
+
+    Assert.IsEqual(result.value, '')
+    Assert.IsEqual(result.next, result)
+  })
+
+  it('should handle deeply nested circular structures', () => {
+    const input = {
+      id: 'root',
+      child: {
+        id: 'child',
+        parent: null,
+      },
+    }
+
+    // Create circular reference
+    // @ts-expect-error
+    input.child.parent = input
+
+    const schema = Type.Recursive((This) =>
+      Type.Object({
+        id: Type.String(),
+        child: Type.Object({
+          id: Type.String(),
+          parent: Type.Union([This, Type.Null()]),
+        }),
+      }),
+    )
+
+    const result = Value.Cast(schema, input)
+
+    Assert.IsEqual(result.id, 'root')
+    Assert.IsEqual(result.child.id, 'child')
+    Assert.IsEqual(result.child.parent, result)
+  })
+
+  it('should handle circular array with multiple references', () => {
+    const node1 = { id: 'node1', refs: [] }
+    const node2 = { id: 'node2', refs: [] }
+
+    // @ts-expect-error
+    node1.refs = [node2, node1]
+    // @ts-expect-error
+    node2.refs = [node1]
+
+    const schema = Type.Recursive((This) =>
+      Type.Object({
+        id: Type.String(),
+        refs: Type.Array(This),
+      }),
+    )
+
+    const result = Value.Cast(schema, node1)
+
+    Assert.IsEqual(result.id, 'node1')
+    Assert.IsEqual(result.refs.length, 2)
+    Assert.IsEqual(result.refs[0].id, 'node2')
+    Assert.IsEqual(result.refs[1], result)
+    Assert.IsEqual(result.refs[0].refs[0], result)
+  })
+
+  it('should handle optional properties in circular structures', () => {
+    const input = {
+      id: 'test',
+      parent: undefined,
+    }
+
+    // @ts-expect-error
+    input.parent = input
+
+    const schema = Type.Recursive((This) =>
+      Type.Object({
+        id: Type.String(),
+        parent: Type.Optional(This),
+        metadata: Type.Optional(Type.String()),
+      }),
+    )
+
+    const result = Value.Cast(schema, input)
+
+    Assert.IsEqual(result.id, 'test')
+    Assert.IsEqual(result.parent, result)
+    Assert.IsEqual(result.metadata, undefined)
+  })
+
+  it('should handle mixed circular and non-circular references', () => {
+    const leaf = { id: 'leaf', children: [] }
+    const branch = { id: 'branch', children: [leaf] }
+    const root = { id: 'root', children: [branch] }
+
+    // Add circular reference
+    // @ts-expect-error
+    branch.children.push(root)
+
+    const schema = Type.Recursive((This) =>
+      Type.Object({
+        id: Type.String(),
+        children: Type.Array(This),
+      }),
+    )
+
+    const result = Value.Cast(schema, root)
+
+    Assert.IsEqual(result.id, 'root')
+    Assert.IsEqual(result.children.length, 1)
+    Assert.IsEqual(result.children[0].id, 'branch')
+    Assert.IsEqual(result.children[0].children.length, 2)
+    Assert.IsEqual(result.children[0].children[0].id, 'leaf')
+    Assert.IsEqual(result.children[0].children[1], result)
+  })
+
+  it('should handle circular references with union types', () => {
+    const textNode = {
+      type: 'text',
+      content: 'Hello',
+      parent: null,
+    }
+
+    const containerNode = {
+      type: 'container',
+      children: [textNode],
+      parent: null,
+    }
+
+    // @ts-expect-error
+    textNode.parent = containerNode
+    // @ts-expect-error
+    containerNode.parent = containerNode // self-reference
+
+    const schema = Type.Recursive((This) =>
+      Type.Union([
+        Type.Object({
+          type: Type.Literal('text'),
+          content: Type.String(),
+          parent: Type.Union([This, Type.Null()]),
+        }),
+        Type.Object({
+          type: Type.Literal('container'),
+          children: Type.Array(This),
+          parent: Type.Union([This, Type.Null()]),
+        }),
+      ]),
+    )
+
+    const result = Value.Cast(schema, containerNode)
+
+    Assert.IsEqual(result.type, 'container')
+    // @ts-expect-error - TypeScript can't infer the union type here
+    Assert.IsEqual(result.children.length, 1)
+    // @ts-expect-error
+    Assert.IsEqual(result.children[0].type, 'text')
+    // @ts-expect-error
+    Assert.IsEqual(result.children[0].content, 'Hello')
+    // @ts-expect-error
+    Assert.IsEqual(result.children[0].parent, result)
+    Assert.IsEqual(result.parent, result)
+  })
 })

--- a/test/runtime/value/check/recursive.ts
+++ b/test/runtime/value/check/recursive.ts
@@ -66,4 +66,53 @@ describe('value/check/Recursive', () => {
     const result = Value.Check(T, value)
     Assert.IsEqual(result, false)
   })
+
+  // ------------------------------------------------------------------------
+  // ref: https://github.com/sinclairzx81/typebox/issues/1302
+  // ------------------------------------------------------------------------
+  it('should not break when checking a circular structure #1', () => {
+    const value = {
+      id: '1',
+      nodes: [],
+    }
+
+    // @ts-expect-error
+    value.nodes[0] = value
+
+    const result = Value.Check(T, value)
+    Assert.IsEqual(result, true)
+  })
+
+  it('should not break when checking a circular structure #2', () => {
+    const value = {
+      id: 1,
+      nodes: [],
+    }
+
+    // @ts-expect-error
+    value.nodes[0] = value
+
+    const result = Value.Check(T, value)
+    Assert.IsEqual(result, false)
+  })
+
+  it('should not break when checking a circular structure #3', () => {
+    const value = {
+      a: '',
+    }
+
+    // @ts-expect-error
+    value.b = value
+
+    const T = Type.Recursive((This) =>
+      Type.Object({
+        a: Type.String(),
+        b: This,
+      }),
+    )
+
+    const result = Value.Check(T, value)
+
+    Assert.IsEqual(result, true)
+  })
 })

--- a/test/runtime/value/clone/clone.ts
+++ b/test/runtime/value/clone/clone.ts
@@ -153,4 +153,101 @@ describe('value/clone/Clone', () => {
     const R = Value.Clone(V)
     Assert.IsEqual(R, V)
   })
+  // ------------------------------------------------------------------------
+  // ref: https://github.com/sinclairzx81/typebox/issues/1300
+  // ------------------------------------------------------------------------
+  it('Should handle circular references #1', () => {
+    const V = { a: 1, b: { c: 2 } } as any
+    V.b.d = V.b
+    const R = Value.Clone(V)
+    Assert.IsEqual(R, V)
+  })
+  it('Should handle circular references #2', () => {
+    const V = { a: {}, b: {} } as any
+    V.a.c = V.b
+    V.b.d = V.a
+    const R = Value.Clone(V)
+    console.log(R)
+    Assert.IsEqual(R, V)
+  })
+  it('Should handle indirect circular references #1', () => {
+    // Create a chain: A -> B -> C -> A
+    const A = { name: 'A' } as any
+    const B = { name: 'B' } as any
+    const C = { name: 'C' } as any
+
+    A.next = B
+    B.next = C
+    C.next = A // Circular reference through chain
+
+    const R = Value.Clone(A)
+    Assert.IsEqual(R.name, 'A')
+    Assert.IsEqual(R.next.name, 'B')
+    Assert.IsEqual(R.next.next.name, 'C')
+    Assert.IsEqual(R.next.next.next, R) // Should reference back to root
+  })
+  it('Should handle indirect circular references #2', () => {
+    // Create a more complex structure with multiple indirect references
+    const root = {
+      data: { value: 1 },
+      children: [],
+      metadata: {},
+    } as any
+
+    const child1 = {
+      id: 1,
+      parent: root,
+      siblings: [],
+    } as any
+
+    const child2 = {
+      id: 2,
+      parent: root,
+      siblings: [],
+    } as any
+
+    // Set up the circular references
+    root.children = [child1, child2]
+    child1.siblings = [child2]
+    child2.siblings = [child1]
+    root.metadata.firstChild = child1
+
+    const R = Value.Clone(root)
+
+    // Verify structure integrity
+    Assert.IsEqual(R.data.value, 1)
+    Assert.IsEqual(R.children.length, 2)
+    Assert.IsEqual(R.children[0].id, 1)
+    Assert.IsEqual(R.children[1].id, 2)
+
+    // Verify circular references are maintained
+    Assert.IsEqual(R.children[0].parent, R)
+    Assert.IsEqual(R.children[1].parent, R)
+    Assert.IsEqual(R.children[0].siblings[0], R.children[1])
+    Assert.IsEqual(R.children[1].siblings[0], R.children[0])
+    Assert.IsEqual(R.metadata.firstChild, R.children[0])
+  })
+  it('Should handle deep indirect circular references', () => {
+    // Create a deeply nested structure with circular reference at the end
+    const V = {
+      level1: {
+        level2: {
+          level3: {
+            level4: {
+              level5: {},
+            },
+          },
+        },
+      },
+    } as any
+
+    // Create circular reference from deep level back to root
+    V.level1.level2.level3.level4.level5.backToRoot = V
+    V.level1.level2.level3.level4.level5.backToLevel2 = V.level1.level2
+
+    const R = Value.Clone(V)
+
+    // Verify the structure and circular references
+    Assert.IsEqual(R, V)
+  })
 })


### PR DESCRIPTION
The current `Clone`, `Check` and `Cast` functions does not handle recursive (circular) structures. When an object references itself, the function runs into infinite recursion and throws a Maximum call stack size exceeded error.

```ts
const a = { x: 1 };
a.b = a;

Clone(a); // ❌ Fails with Maximum call stack error
```

This PR adds support for recursive structures by detecting and handling circular references. Objects that reference themselves (directly or indirectly) can now be processed safely without causing stack overflows.